### PR TITLE
Add support for _struct.pdbx_model_details

### DIFF
--- a/ihm/__init__.py
+++ b/ihm/__init__.py
@@ -72,13 +72,16 @@ class System(object):
 
        :param str title: Title (longer text description) of the system.
        :param str id: Unique identifier for this system in the mmCIF file.
+       :param str model_details: Detailed description of the system, like an
+                                 abstract.
     """
 
     structure_determination_methodology = "integrative"
 
-    def __init__(self, title=None, id='model'):
+    def __init__(self, title=None, id='model', model_details=None):
         self.id = id
         self.title = title
+        self.model_details = model_details
 
         #: List of plain text comments. These will be added to the top of
         #: the mmCIF file.

--- a/ihm/dumper.py
+++ b/ihm/dumper.py
@@ -92,7 +92,8 @@ class _StructDumper(Dumper):
         with writer.category("_struct") as lp:
             mth = system.structure_determination_methodology
             lp.write(title=system.title, entry_id=system.id,
-                     pdbx_structure_determination_methodology=mth)
+                     pdbx_structure_determination_methodology=mth,
+                     pdbx_model_details=system.model_details)
 
 
 class _CommentDumper(Dumper):

--- a/ihm/reader.py
+++ b/ihm/reader.py
@@ -878,6 +878,7 @@ class _StructHandler(Handler):
                              mapkeys={'entry_id': 'id',
                                       'pdbx_model_details': 'model_details'})
 
+
 class _AuditConformHandler(Handler):
     category = '_audit_conform'
 

--- a/ihm/reader.py
+++ b/ihm/reader.py
@@ -873,10 +873,10 @@ class Handler(object):
 class _StructHandler(Handler):
     category = '_struct'
 
-    def __call__(self, title, entry_id):
+    def __call__(self, title, entry_id, pdbx_model_details):
         self.copy_if_present(self.system, locals(), keys=('title',),
-                             mapkeys={'entry_id': 'id'})
-
+                             mapkeys={'entry_id': 'id',
+                                      'pdbx_model_details': 'model_details'})
 
 class _AuditConformHandler(Handler):
     category = '_audit_conform'

--- a/test/test_dumper.py
+++ b/test/test_dumper.py
@@ -51,7 +51,7 @@ class Tests(unittest.TestCase):
         ihm.dumper.write(fh, [sys1, sys2])
         lines = fh.getvalue().split('\n')
         self.assertEqual(lines[:2], ["data_system1", "_entry.id system1"])
-        self.assertEqual(lines[15:17],
+        self.assertEqual(lines[16:18],
                          ["data_system23", "_entry.id 'system 2+3'"])
 
     def test_write_custom_dumper(self):
@@ -117,10 +117,11 @@ class Tests(unittest.TestCase):
 
     def test_struct_dumper(self):
         """Test StructDumper"""
-        system = ihm.System(title='test model')
+        system = ihm.System(title='test model', model_details="test details")
         dumper = ihm.dumper._StructDumper()
         out = _get_dumper_output(dumper, system)
         self.assertEqual(out, """_struct.entry_id model
+_struct.pdbx_model_details 'test details'
 _struct.pdbx_structure_determination_methodology integrative
 _struct.title 'test model'
 """)

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -41,7 +41,7 @@ class Tests(unittest.TestCase):
             # can read it
             with open(os.path.join(tmpdir, 'output.cif')) as fh:
                 contents = fh.readlines()
-            self.assertEqual(len(contents), 315)
+            self.assertEqual(len(contents), 316)
             with open(os.path.join(tmpdir, 'output.cif')) as fh:
                 s, = ihm.reader.read(fh)
 
@@ -55,7 +55,7 @@ class Tests(unittest.TestCase):
         # can read it
         with open(out) as fh:
             contents = fh.readlines()
-        self.assertEqual(len(contents), 69)
+        self.assertEqual(len(contents), 70)
         with open(out) as fh:
             s, = ihm.reader.read(fh)
         os.unlink(out)
@@ -70,7 +70,7 @@ class Tests(unittest.TestCase):
         # can read it
         with open(out) as fh:
             contents = fh.readlines()
-        self.assertEqual(len(contents), 251)
+        self.assertEqual(len(contents), 252)
         with open(out) as fh:
             s, = ihm.reader.read(fh)
         # Make sure that resulting Python objects are picklable
@@ -92,7 +92,7 @@ class Tests(unittest.TestCase):
         # can read it
         with open(out) as fh:
             contents = fh.readlines()
-        self.assertEqual(len(contents), 65)
+        self.assertEqual(len(contents), 66)
         with open(out) as fh:
             s, = ihm.reader.read(fh)
         os.unlink(out)

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -177,11 +177,16 @@ class Tests(unittest.TestCase):
 
     def test_struct_handler(self):
         """Test StructHandler"""
-        cif = "_struct.entry_id eid\n_struct.title 'Test title'"
+        cif = """
+_struct.entry_id eid
+_struct.title 'Test title'
+_struct.pdbx_model_details 'Test details'
+"""
         for fh in cif_file_handles(cif):
             s, = ihm.reader.read(fh)
             self.assertEqual(s.id, 'eid')
             self.assertEqual(s.title, 'Test title')
+            self.assertEqual(s.model_details, 'Test details')
 
     def test_multiple_systems(self):
         """Test multiple systems from data blocks"""


### PR DESCRIPTION
For ModelArchive we need the `_struct.pdbx_model_details` field. I tried to add it to ihm by extending `ihm.System` and the struct dumper. Unit tests were also adapted by creating file output and running diff to make sure that just the `_struct.pdbx_model_details` line was added. Documentation builds and shows the changes.