### PR TITLE
Add citation for QMEANDisCo.

### DIFF
--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -51,3 +51,7 @@ The :mod:`ihm.citations` Python module
 .. data:: colabfold
 
    ColabFold: accessible AlphaFold pipeline.
+
+.. data: qmeandisco
+
+   QMEANDisCo: model quality estimation with distance constraints.

--- a/ihm/citations.py
+++ b/ihm/citations.py
@@ -119,13 +119,13 @@ colabfold = ihm.Citation(
     doi='10.1038/s41592-022-01488-1')
 
 qmeandisco = ihm.Citation(
-            pmid='31697312',
-            title='QMEANDisCo-distance constraints applied on model quality '
-                  'estimation.',
-            journal='Bioinformatics',
-            volume=36,
-            page_range=(1765, 1771),
-            year=2019,
-            authors=['Studer, G.', 'Rempfer, C.', 'Waterhouse, A.M.',
-                     'Gumienny, R.', 'Haas, J.', 'Schwede, T.'],
-            doi='10.1093/bioinformatics/btz828')
+    pmid='31697312',
+    title='QMEANDisCo-distance constraints applied on model quality '
+          'estimation.',
+    journal='Bioinformatics',
+    volume=36,
+    page_range=(1765, 1771),
+    year=2019,
+    authors=['Studer, G.', 'Rempfer, C.', 'Waterhouse, A.M.', 'Gumienny, R.',
+             'Haas, J.', 'Schwede, T.'],
+    doi='10.1093/bioinformatics/btz828')

--- a/ihm/citations.py
+++ b/ihm/citations.py
@@ -117,3 +117,15 @@ colabfold = ihm.Citation(
     authors=['Mirdita, M.', 'Schuetze, K.', 'Moriwaki, Y.', 'Heo, L.',
              'Ovchinnikov, S.', 'Steinegger, M.'],
     doi='10.1038/s41592-022-01488-1')
+
+qmeandisco = ihm.Citation(
+            pmid='31697312',
+            title='QMEANDisCo-distance constraints applied on model quality '
+                  'estimation.',
+            journal='Bioinformatics',
+            volume=36,
+            page_range=(1765, 1771),
+            year=2019,
+            authors=['Studer, G.', 'Rempfer, C.', 'Waterhouse, A.M.',
+                     'Gumienny, R.', 'Haas, J.', 'Schwede, T.'],
+            doi='10.1093/bioinformatics/btz828')


### PR DESCRIPTION
I added [QMEANDisCo](https://swissmodel.expasy.org/qmean/) to the list of `ihm.citations` - will be in all future ModelCIF files of [SWISS-MODEL](https://swissmodel.expasy.org) and maybe some model providers of [3D-Beacons](https://www.ebi.ac.uk/pdbe/pdbe-kb/3dbeacons/) will also use it.