### PR TITLE
Add support for updates in IHMCIF required for unification with PDB

### DIFF
--- a/ihm/dataset.py
+++ b/ihm/dataset.py
@@ -104,7 +104,7 @@ class DatasetGroup(list):
 
 class CXMSDataset(Dataset):
     """Processed cross-links from a CX-MS experiment"""
-    data_type = 'CX-MS data'
+    data_type = 'Crosslinking-MS data'
 
 
 class MassSpecDataset(Dataset):

--- a/ihm/dumper.py
+++ b/ihm/dumper.py
@@ -1854,7 +1854,7 @@ class _OrderedDumper(Dumper):
                     edge._id = next(edge_id)
 
     def dump(self, system, writer):
-        with writer.loop("_ihm_ordered_ensemble",
+        with writer.loop("_ihm_ordered_model",
                          ["process_id", "process_description", "ordered_by",
                           "step_id", "step_description",
                           "edge_id", "edge_description",

--- a/ihm/reader.py
+++ b/ihm/reader.py
@@ -2920,7 +2920,7 @@ class _CrossLinkResultHandler(Handler):
             sigma2=self.get_float(sigma_2))
 
 
-class _OrderedEnsembleHandler(Handler):
+class _OrderedModelHandler(Handler):
     category = '_ihm_ordered_model'
 
     def __call__(self, process_id, step_id, model_group_id_begin,
@@ -2944,6 +2944,12 @@ class _OrderedEnsembleHandler(Handler):
             mapkeys={'process_description': 'description'})
         self.copy_if_present(
             step, locals(), mapkeys={'step_description': 'description'})
+
+
+# Handle the old name for the ihm_ordered_model category. This is a separate
+# object so relies on _OrderedModelHandler not storing any state.
+class _OrderedEnsembleHandler(_OrderedModelHandler):
+    category = '_ihm_ordered_ensemble'
 
 
 class UnknownCategoryWarning(Warning):
@@ -3773,7 +3779,7 @@ class IHMVariant(Variant):
         _BranchDescriptorHandler, _BranchLinkHandler, _CrossLinkListHandler,
         _CrossLinkRestraintHandler, _CrossLinkPseudoSiteHandler,
         _CrossLinkResultHandler, _StartingModelSeqDifHandler,
-        _OrderedEnsembleHandler,
+        _OrderedModelHandler, _OrderedEnsembleHandler,
         _MultiStateSchemeHandler, _MultiStateSchemeConnectivityHandler,
         _KineticRateHandler,
         _RelaxationTimeHandler, _RelaxationTimeMultiStateSchemeHandler

--- a/ihm/reader.py
+++ b/ihm/reader.py
@@ -2921,7 +2921,7 @@ class _CrossLinkResultHandler(Handler):
 
 
 class _OrderedEnsembleHandler(Handler):
-    category = '_ihm_ordered_ensemble'
+    category = '_ihm_ordered_model'
 
     def __call__(self, process_id, step_id, model_group_id_begin,
                  model_group_id_end, edge_description, ordered_by,

--- a/ihm/reader.py
+++ b/ihm/reader.py
@@ -1481,6 +1481,8 @@ class _DatasetListHandler(Handler):
             (x[1].data_type.lower(), x[1])
             for x in inspect.getmembers(ihm.dataset, inspect.isclass)
             if issubclass(x[1], ihm.dataset.Dataset))
+        # Map old 'CX-MS' data to new class
+        self.type_map['cx-ms data'] = ihm.dataset.CXMSDataset
 
     def __call__(self, data_type, id, details):
         typ = None if data_type is None else data_type.lower()

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -101,7 +101,7 @@ class Tests(unittest.TestCase):
         """Test CXMSDataset"""
         loc = ihm.location.FileLocation(repo='mydoi', path='a')
         d = ihm.dataset.CXMSDataset(loc)
-        self.assertEqual(d.data_type, 'CX-MS data')
+        self.assertEqual(d.data_type, 'Crosslinking-MS data')
 
     def test_hdx_dataset(self):
         """Test HDXDataset"""

--- a/test/test_dumper.py
+++ b/test/test_dumper.py
@@ -1430,8 +1430,8 @@ _ihm_dataset_list.id
 _ihm_dataset_list.data_type
 _ihm_dataset_list.database_hosted
 _ihm_dataset_list.details
-1 'CX-MS data' NO .
-2 'CX-MS data' NO .
+1 'Crosslinking-MS data' NO .
+2 'Crosslinking-MS data' NO .
 3 Other YES bar
 4 Other YES baz
 5 'Experimental model' YES 'test dataset details'

--- a/test/test_dumper.py
+++ b/test/test_dumper.py
@@ -2742,15 +2742,15 @@ _ihm_multi_state_model_group_link.model_group_id
         out = _get_dumper_output(dumper, system)
         self.assertEqual(out, """#
 loop_
-_ihm_ordered_ensemble.process_id
-_ihm_ordered_ensemble.process_description
-_ihm_ordered_ensemble.ordered_by
-_ihm_ordered_ensemble.step_id
-_ihm_ordered_ensemble.step_description
-_ihm_ordered_ensemble.edge_id
-_ihm_ordered_ensemble.edge_description
-_ihm_ordered_ensemble.model_group_id_begin
-_ihm_ordered_ensemble.model_group_id_end
+_ihm_ordered_model.process_id
+_ihm_ordered_model.process_description
+_ihm_ordered_model.ordered_by
+_ihm_ordered_model.step_id
+_ihm_ordered_model.step_description
+_ihm_ordered_model.edge_id
+_ihm_ordered_model.edge_description
+_ihm_ordered_model.model_group_id_begin
+_ihm_ordered_model.model_group_id_end
 1 . 'time steps' 1 'Linear reaction' 1 . 42 82
 2 'Proc 2' 'time steps' 1 'Branched reaction' 1 . 42 82
 2 'Proc 2' 'time steps' 1 'Branched reaction' 2 . 42 92

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -3140,8 +3140,9 @@ _ihm_cross_link_result_parameters.sigma_2
             self.assertIsNone(fits[1][1].sigma1)
             self.assertIsNone(fits[1][1].sigma2)
 
-    def test_ordered_ensemble_handler(self):
-        """Test OrderedEnsembleHandler"""
+    def test_ordered_model_handler(self):
+        """Test OrderedModelHandler"""
+        # Test both old and new category names
         fh = StringIO("""
 loop_
 _ihm_ordered_model.process_id
@@ -3155,6 +3156,17 @@ _ihm_ordered_model.model_group_id_begin
 _ihm_ordered_model.model_group_id_end
 1 pdesc 'steps in a reaction pathway' 1 'step 1 desc' 1 .  1 2
 1 pdesc 'steps in a reaction pathway' 2 'step 2 desc' 2 'edge 2 desc'  1 3
+#
+loop_
+_ihm_ordered_ensemble.process_id
+_ihm_ordered_ensemble.process_description
+_ihm_ordered_ensemble.ordered_by
+_ihm_ordered_ensemble.step_id
+_ihm_ordered_ensemble.step_description
+_ihm_ordered_ensemble.edge_id
+_ihm_ordered_ensemble.edge_description
+_ihm_ordered_ensemble.model_group_id_begin
+_ihm_ordered_ensemble.model_group_id_end
 1 pdesc 'steps in a reaction pathway' 2 'step 2 desc' 3 .  1 4
 """)
         s, = ihm.reader.read(fh)

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -978,10 +978,12 @@ _ihm_dataset_list.details
 2 'COMPARATIVE MODEL' YES .
 3 'EM raw micrographs' YES 'test details'
 4 . YES .
+5 'Crosslinking-MS data' YES .
+6 'CX-MS data' YES .
 """
         for fh in cif_file_handles(cif):
             s, = ihm.reader.read(fh)
-            d1, d2, d3, d4 = s.orphan_datasets
+            d1, d2, d3, d4, d5, d6 = s.orphan_datasets
             self.assertEqual(d1.__class__, ihm.dataset.PDBDataset)
             self.assertEqual(d2.__class__, ihm.dataset.ComparativeModelDataset)
             self.assertEqual(d3.__class__, ihm.dataset.EMMicrographsDataset)
@@ -992,6 +994,10 @@ _ihm_dataset_list.details
             self.assertEqual(d4.__class__, ihm.dataset.Dataset)
             self.assertIsNone(d1.details)
             self.assertEqual(d3.details, 'test details')
+            # Both new and old data_types should map to the same
+            # crosslink class
+            self.assertEqual(d5.__class__, ihm.dataset.CXMSDataset)
+            self.assertEqual(d6.__class__, ihm.dataset.CXMSDataset)
 
     def test_dataset_group_handler(self):
         """Test DatasetGroupHandler"""

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -3144,15 +3144,15 @@ _ihm_cross_link_result_parameters.sigma_2
         """Test OrderedEnsembleHandler"""
         fh = StringIO("""
 loop_
-_ihm_ordered_ensemble.process_id
-_ihm_ordered_ensemble.process_description
-_ihm_ordered_ensemble.ordered_by
-_ihm_ordered_ensemble.step_id
-_ihm_ordered_ensemble.step_description
-_ihm_ordered_ensemble.edge_id
-_ihm_ordered_ensemble.edge_description
-_ihm_ordered_ensemble.model_group_id_begin
-_ihm_ordered_ensemble.model_group_id_end
+_ihm_ordered_model.process_id
+_ihm_ordered_model.process_description
+_ihm_ordered_model.ordered_by
+_ihm_ordered_model.step_id
+_ihm_ordered_model.step_description
+_ihm_ordered_model.edge_id
+_ihm_ordered_model.edge_description
+_ihm_ordered_model.model_group_id_begin
+_ihm_ordered_model.model_group_id_end
 1 pdesc 'steps in a reaction pathway' 1 'step 1 desc' 1 .  1 2
 1 pdesc 'steps in a reaction pathway' 2 'step 2 desc' 2 'edge 2 desc'  1 3
 1 pdesc 'steps in a reaction pathway' 2 'step 2 desc' 3 .  1 4


### PR DESCRIPTION
This adds support for IHMCIF dictionary updates in its `remediation` branch:

https://github.com/ihmwg/IHMCIF/tree/remediation

Closes #137.